### PR TITLE
feat: deployment stacks #22 and optional tf storage account #23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 playground.ps1
+**/.env

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can use it to bootstrap demos, or as a lightweight alternative to subscripti
 ```mermaid
 flowchart TD
     A[Creates a new repository<br/> from a GitHub template] --> B[Clone the repository locally]
-    B --> C[Create resource group, <br/>managed identities & RBAC]
+    B --> C[Create resource group, <br/>managed identities & RBAC,<br/>optional TF storage account]
     C --> D[Makes GitHub Environments,<br/>set secrets, reviewers,<br/>and branch protection <br/>in the solution repo]
     D --> E[Now you're ready for<br/>IaC development!]
 ```
@@ -51,6 +51,7 @@ The above will:
 - Grants Reader to the plan identity and Contributor + RBAC Administrator (RBAC) roles to the apply managed identity at the resource group level
 - Sets up federated credentials for GitHub environments (defautl naming: "dev-iac-plan" and "dev-iac-apply")
 - Configures GitHub environments, secrets, and branch protection in the new target repository.
+- v0.4 - Creates an optional storage account for Terraform state, assigning both identities `Storage Blob Data Contributor`.
 
 Naming conventions can be overriden to suit, for example, to include a location in the RG and MI name, you could do this:
 
@@ -61,8 +62,10 @@ $params = @{
   TargetRepoName           = "$name"
   ResourceGroupName        = "rg-$name-dev-nzn-01"
   PlanManagedIdentityName  = "mi-$name-dev-nzn-01-plan"
-  ApplyManagedIdentityName = "mi-$name-dev-nzn-01-plan" 
+  ApplyManagedIdentityName = "mi-$name-dev-nzn-01-plan" \
   Location                 = "newzealandnorth"
+  # if you want to have a pre-made Terraform state file, complete with a bit of randomness for good luck:
+  TerraformStateStorageAccountName = "st{0}devnzn{1}" -f $name.replace("-",""), $([System.Guid]::NewGuid().ToString('N').Substring(0,4))
 }
 Invoke-AzBootstrap @params
 ```
@@ -112,6 +115,9 @@ $params = @{
   
   # Where to clone repo locally (default: ".\$TargetRepoName")
   TargetDirectory = "D:\src\kewalaka\demos\$name" 
+  
+  # Terraform State Storage account
+  TerraformStateStorageAccount = "strasndn23914"
   
   # "private" or "public" (default: "public")
   Visibility = "private"             

--- a/az-bootstrap.psd1
+++ b/az-bootstrap.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'az-bootstrap.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.3.1'
+    ModuleVersion     = '0.4.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/integration-tests/.env.example
+++ b/integration-tests/.env.example
@@ -8,4 +8,4 @@ gitHubOwner=your-github-username
 gitHubRepo=your-repo-name
 gitHubPlanEnvironmentName=dev-iac-plan
 gitHubApplyEnvironmentName=dev-iac-apply
-storageAccountName=azbteststorage
+terraformStateStorageAccountName=azbteststorage

--- a/integration-tests/.env.example
+++ b/integration-tests/.env.example
@@ -1,0 +1,11 @@
+# Example .env file for integration/bicep-validation.ps1
+# Copy to .env and fill in your real values
+resourceGroupName=azb-test-rg
+location=eastus
+planManagedIdentityName=azb-test-plan-mi
+applyManagedIdentityName=azb-test-apply-mi
+gitHubOwner=your-github-username
+gitHubRepo=your-repo-name
+gitHubPlanEnvironmentName=dev-iac-plan
+gitHubApplyEnvironmentName=dev-iac-apply
+storageAccountName=azbteststorage

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,12 @@
+# Bicep integration test
+
+This folder exists to help test changes to the Bicep template used for deployment.
+
+To use, populate the `.env` file (see `.env.example` for illustration), and then call `bicep-validation.ps1`
+
+This will call the bicep template in `/templates/environment-infra.bicep` in 'what-if' mode.
+
+The `.env` file is used to simulate the process of passing params from Az-Bootstrap,
+designed to be similar to the logic in `/private/New-AzBicepDeployment.ps1`
+
+TODO - be good to have this included as part of CI testing.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -2,9 +2,10 @@
 
 This folder exists to help test changes to the Bicep template used for deployment.
 
-To use, populate the `.env` file (see `.env.example` for illustration), and then call `bicep-validation.ps1`
+To use, populate the `.env` file (see `.env.example` for illustration).
 
-This will call the bicep template in `/templates/environment-infra.bicep` in 'what-if' mode.
+* `bicep-validation.ps1 -whatif` will do a what-if deployment on the resources
+* `bicep-validation.ps1 -deploy` will use a deployment stack to deploy resources in `/templates/environment-infra.bicep`.
 
 The `.env` file is used to simulate the process of passing params from Az-Bootstrap,
 designed to be similar to the logic in `/private/New-AzBicepDeployment.ps1`

--- a/integration-tests/bicep-validation.ps1
+++ b/integration-tests/bicep-validation.ps1
@@ -1,0 +1,47 @@
+function Load-DotEnv {
+    param(
+        [string]$Path = ".env"
+    )
+    if (-Not (Test-Path $Path)) {
+        throw ".env file not found at $Path. Please create one (see .env.example)."
+    }
+    $result = @{}
+    Get-Content $Path | ForEach-Object {
+        if ($_ -match '^\s*#|^\s*$') { return } # skip comments/empty
+        if ($_ -match '^(.*?)=(.*)$') {
+            $name = $matches[1].Trim()
+            $value = $matches[2].Trim()
+            $result[$name] = $value
+        }
+    }
+    return $result
+}
+
+# Load environment variables from .env as a hashtable
+$scriptpath = if ($PSScriptRoot) { $PSScriptRoot } else { "." }
+
+$bicepParams = Load-DotEnv -Path "$scriptpath/.env"
+
+# Validate required params and remove table header
+$activeBicepParams = $bicepParams.GetEnumerator() | Where-Object { $_.Value -ne $null } | ForEach-Object { "$($_.Name)=$($_.Value)" }
+
+# Example: Run Bicep deployment as a stack (recommended for lifecycle management)
+$stackName = "azb-stack-$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
+$deploymentCmd = @(
+    'az stack sub create',
+    "--name $stackName",
+    "--location $($bicepParams.location)",
+    "--template-file ../templates/environment-infra.bicep",
+    "--action-on-unmanage deleteResources",
+    "--deny-settings-mode none",
+    "--parameters"
+)
+
+$deploymentCmd += $activeBicepParams
+$deploymentCmd = $deploymentCmd -join ' '
+
+Write-Host "Running: $deploymentCmd"
+Invoke-Expression $deploymentCmd
+
+Write-Host "\nTo delete the stack and all managed resources, run:"
+Write-Host "az stack sub delete --name $stackName --yes --action-on-unmanage deleteResources"

--- a/integration/.env.example
+++ b/integration/.env.example
@@ -1,0 +1,12 @@
+# Example .env file for integration/bicep-validation.ps1
+# Copy to .env and fill in your real values
+ResourceGroupName=azb-test-rg
+Location=eastus
+PlanManagedIdentityName=azb-test-plan-mi
+ApplyManagedIdentityName=azb-test-apply-mi
+GitHubOwner=your-github-username
+GitHubRepo=your-repo-name
+PlanEnvName=dev-iac-plan
+ApplyEnvName=dev-iac-apply
+ArmSubscriptionId=00000000-0000-0000-0000-000000000000
+DeploymentName=azb-test-deploy

--- a/private/New-AzBicepDeployment.ps1
+++ b/private/New-AzBicepDeployment.ps1
@@ -52,7 +52,6 @@ function New-AzBicepDeployment {
     '--name', $stackName,
     '--location', $Location,
     '--template-file', $resolvedBicepTemplateFile,
-    '--deployment-resource-group', $ResourceGroupName,
     '--action-on-unmanage', 'deleteResources',
     '--deny-settings-mode', 'none',
     '--parameters'

--- a/private/New-AzBicepDeployment.ps1
+++ b/private/New-AzBicepDeployment.ps1
@@ -33,15 +33,15 @@ function New-AzBicepDeployment {
   Write-Host "[az-bootstrap] This may take a few minutes, please wait..."
 
   $bicepParams = @{
-    resourceGroupName          = $ResourceGroupName
-    location                   = $Location
-    planManagedIdentityName    = $PlanManagedIdentityName
-    applyManagedIdentityName   = $ApplyManagedIdentityName
-    gitHubOwner                = $GitHubOwner.ToLower()
-    gitHubRepo                 = $GitHubRepo.ToLower()
-    gitHubPlanEnvironmentName  = $PlanEnvName.ToLower()
-    gitHubApplyEnvironmentName = $ApplyEnvName.ToLower()
-    storageAccountName         = $TerraformStateStorageAccountName
+    resourceGroupName                = $ResourceGroupName
+    location                         = $Location
+    planManagedIdentityName          = $PlanManagedIdentityName
+    applyManagedIdentityName         = $ApplyManagedIdentityName
+    gitHubOwner                      = $GitHubOwner.ToLower()
+    gitHubRepo                       = $GitHubRepo.ToLower()
+    gitHubPlanEnvironmentName        = $PlanEnvName.ToLower()
+    gitHubApplyEnvironmentName       = $ApplyEnvName.ToLower()
+    terraformStateStorageAccountName = $TerraformStateStorageAccountName
   }
   # Remove any parameters with $null values, as Bicep might error on `paramName=$null`
   $activeBicepParams = $bicepParams.GetEnumerator() | Where-Object { $_.Value -ne $null } | ForEach-Object { "$( $_.Name )=$( $_.Value )" }

--- a/private/New-AzEnvironmentInfrastructure.ps1
+++ b/private/New-AzEnvironmentInfrastructure.ps1
@@ -74,7 +74,7 @@ function New-AzEnvironmentInfrastructure {
   }
 
   $deploymentOutput = $stdout | ConvertFrom-Json -ErrorAction SilentlyContinue
-  if (-not $deploymentOutput -or -not $deploymentOutput.properties -or -not $deploymentOutput.properties.outputs) {
+  if (-not $deploymentOutput -or -not $deploymentOutput.outputs) {
       Write-Error "[az-bootstrap] Bicep deployment outputs not found or failed to parse. Raw STDOUT: $stdout"
       throw "Bicep deployment for environment '$EnvironmentName' did not produce expected outputs."
   }
@@ -84,17 +84,17 @@ function New-AzEnvironmentInfrastructure {
   $applyManagedIdentityClientId = $null
   $applyManagedIdentityPrincipalId = $null
 
-  if ($deploymentOutput.properties.outputs.planManagedIdentityClientId) {
-    $planManagedIdentityClientId = $deploymentOutput.properties.outputs.planManagedIdentityClientId.value
+  if ($deploymentOutput.outputs.planManagedIdentityClientId) {
+    $planManagedIdentityClientId = $deploymentOutput.outputs.planManagedIdentityClientId.value
   }
-  if ($deploymentOutput.properties.outputs.planManagedIdentityPrincipalId) {
-    $planManagedIdentityPrincipalId = $deploymentOutput.properties.outputs.planManagedIdentityPrincipalId.value
+  if ($deploymentOutput.outputs.planManagedIdentityPrincipalId) {
+    $planManagedIdentityPrincipalId = $deploymentOutput.outputs.planManagedIdentityPrincipalId.value
   }
-  if ($deploymentOutput.properties.outputs.applyManagedIdentityClientId) {
-    $applyManagedIdentityClientId = $deploymentOutput.properties.outputs.applyManagedIdentityClientId.value
+  if ($deploymentOutput.outputs.applyManagedIdentityClientId) {
+    $applyManagedIdentityClientId = $deploymentOutput.outputs.applyManagedIdentityClientId.value
   }
-  if ($deploymentOutput.properties.outputs.applyManagedIdentityPrincipalId) {
-    $applyManagedIdentityPrincipalId = $deploymentOutput.properties.outputs.applyManagedIdentityPrincipalId.value
+  if ($deploymentOutput.outputs.applyManagedIdentityPrincipalId) {
+    $applyManagedIdentityPrincipalId = $deploymentOutput.outputs.applyManagedIdentityPrincipalId.value
   }
 
   if (-not $planManagedIdentityClientId -or -not $planManagedIdentityPrincipalId) {
@@ -109,10 +109,10 @@ function New-AzEnvironmentInfrastructure {
   Write-Verbose "[az-bootstrap] Apply MI Client ID: $applyManagedIdentityClientId"
   
   return [PSCustomObject]@{
-    PlanManagedIdentityClientId    = $planManagedIdentityClientId
-    PlanManagedIdentityPrincipalId = $planManagedIdentityPrincipalId
-    ApplyManagedIdentityClientId      = $applyManagedIdentityClientId 
-    ApplyManagedIdentityPrincipalId   = $applyManagedIdentityPrincipalId 
+    PlanManagedIdentityClientId     = $planManagedIdentityClientId
+    PlanManagedIdentityPrincipalId  = $planManagedIdentityPrincipalId
+    ApplyManagedIdentityClientId    = $applyManagedIdentityClientId 
+    ApplyManagedIdentityPrincipalId = $applyManagedIdentityPrincipalId 
   }
 }
 

--- a/public/Add-AzBootstrapEnvironment.ps1
+++ b/public/Add-AzBootstrapEnvironment.ps1
@@ -27,7 +27,9 @@ function Add-AzBootstrapEnvironment {
     [bool]$AddOwnerAsReviewer = $true,
 
     [string]$ArmTenantId,
-    [string]$ArmSubscriptionId
+    [string]$ArmSubscriptionId,
+
+    [string]$TerraformStateStorageAccountName
   )
 
   # Retrieve Azure context (Subscription ID and Tenant ID)
@@ -63,7 +65,6 @@ function Add-AzBootstrapEnvironment {
     $PlanManagedIdentityName.Replace("-plan", "-apply")
   }
 
-  Write-Host "[az-bootstrap] Deploying Azure infrastructure for '$EnvironmentName' environment via Bicep..."
   $infraDetails = New-AzBicepDeployment -EnvironmentName $EnvironmentName `
     -ResourceGroupName $ResourceGroupName `
     -Location $Location `
@@ -73,7 +74,8 @@ function Add-AzBootstrapEnvironment {
     -GitHubRepo $RepoInfo.Repo `
     -PlanEnvName $actualPlanEnvName `
     -ApplyEnvName $actualApplyEnvName `
-    -ArmSubscriptionId $ArmSubscriptionId
+    -ArmSubscriptionId $ArmSubscriptionId `
+    -StorageAccountName $TerraformStateStorageAccountName
 
   if (-not $infraDetails) {
     throw "Failed to set up Azure infrastructure for environment '$EnvironmentName'."
@@ -97,7 +99,7 @@ function Add-AzBootstrapEnvironment {
   $secrets = @{
     "ARM_TENANT_ID"       = $ArmTenantId
     "ARM_SUBSCRIPTION_ID" = $ArmSubscriptionId    
-    "ARM_CLIENT_ID" = $infraDetails.ApplyManagedIdentityClientId
+    "ARM_CLIENT_ID"       = $infraDetails.ApplyManagedIdentityClientId
   }  
 
   Set-GitHubEnvironmentSecrets -Owner $RepoInfo.Owner `

--- a/public/Add-AzBootstrapEnvironment.ps1
+++ b/public/Add-AzBootstrapEnvironment.ps1
@@ -75,7 +75,7 @@ function Add-AzBootstrapEnvironment {
     -PlanEnvName $actualPlanEnvName `
     -ApplyEnvName $actualApplyEnvName `
     -ArmSubscriptionId $ArmSubscriptionId `
-    -StorageAccountName $TerraformStateStorageAccountName
+    -TerraformStateStorageAccountName $TerraformStateStorageAccountName
 
   if (-not $infraDetails) {
     throw "Failed to set up Azure infrastructure for environment '$EnvironmentName'."

--- a/public/Invoke-AzBootstrap.ps1
+++ b/public/Invoke-AzBootstrap.ps1
@@ -43,7 +43,7 @@ function Invoke-AzBootstrap {
         [bool]$AddOwnerAsReviewer = $true,
 
         # optional storage account for terraform state
-        [string]$TerraformStateStorageAccountName = "",
+        [string]$TerraformStateStorageAccountName = ""
     )
 
     #region: check parameters

--- a/public/Invoke-AzBootstrap.ps1
+++ b/public/Invoke-AzBootstrap.ps1
@@ -40,8 +40,10 @@ function Invoke-AzBootstrap {
         # deployment reviewers
         [string[]]$ApplyEnvironmentUserReviewers,
         [string[]]$ApplyEnvironmentTeamReviewers,
-        [bool]$AddOwnerAsReviewer = $true
+        [bool]$AddOwnerAsReviewer = $true,
 
+        # optional storage account for terraform state
+        [string]$TerraformStateStorageAccountName = "",
     )
 
     #region: check parameters
@@ -159,20 +161,21 @@ function Invoke-AzBootstrap {
 
         Write-Host "[az-bootstrap] Creating initial environment '$InitialEnvironmentName'..."
         $addEnvParams = @{
-            EnvironmentName               = $InitialEnvironmentName
-            ResourceGroupName             = $initialRgName
-            Location                      = $Location
-            PlanManagedIdentityName       = $planMiName
-            ApplyManagedIdentityName      = $applyMiName
-            ArmTenantId                   = $currentArmTenantId
-            ArmSubscriptionId             = $currentArmSubscriptionId
-            GitHubOwner                   = $RepoInfo.Owner
-            GitHubRepo                    = $RepoInfo.Repo
-            PlanEnvName                   = $initialPlanEnvName
-            ApplyEnvName                  = $initialApplyEnvName
-            ApplyEnvironmentUserReviewers     = $ApplyEnvironmentUserReviewers
-            ApplyEnvironmentTeamReviewers = $ApplyEnvironmentTeamReviewers
-            AddOwnerAsReviewer            = $AddOwnerAsReviewer
+            EnvironmentName                  = $InitialEnvironmentName
+            ResourceGroupName                = $initialRgName
+            Location                         = $Location
+            PlanManagedIdentityName          = $planMiName
+            ApplyManagedIdentityName         = $applyMiName
+            ArmTenantId                      = $currentArmTenantId
+            ArmSubscriptionId                = $currentArmSubscriptionId
+            GitHubOwner                      = $RepoInfo.Owner
+            GitHubRepo                       = $RepoInfo.Repo
+            PlanEnvName                      = $initialPlanEnvName
+            ApplyEnvName                     = $initialApplyEnvName
+            ApplyEnvironmentUserReviewers    = $ApplyEnvironmentUserReviewers
+            ApplyEnvironmentTeamReviewers    = $ApplyEnvironmentTeamReviewers
+            AddOwnerAsReviewer               = $AddOwnerAsReviewer
+            TerraformStateStorageAccountName = $TerraformStateStorageAccountName
         }
 
         $DeploymentEnv = Add-AzBootstrapEnvironment @addEnvParams

--- a/public/Invoke-AzBootstrap.ps1
+++ b/public/Invoke-AzBootstrap.ps1
@@ -188,7 +188,7 @@ function Invoke-AzBootstrap {
         Pop-Location
     }
 
-    Write-Host "[az-bootstrap] Repository  : '$($RepoInfo.Owner)/$($RepoInfo.Repo)'."
+    Write-Host "[az-bootstrap] Repository  : 'https://github.com/$($RepoInfo.Owner)/$($RepoInfo.Repo)'."
     Write-Host "[az-bootstrap] ...cloned to: '$($TargetDirectory)'."
     Write-Host "[az-bootstrap] Azure Bootstrap complete. 🎉"
 }

--- a/templates/environment-infra.bicep
+++ b/templates/environment-infra.bicep
@@ -220,6 +220,9 @@ output planManagedIdentityClientId string = planManagedIdentity.outputs.clientId
 @description('Client ID of the Plan Managed Identity.')
 output applyManagedIdentityClientId string = applyManagedIdentity.outputs.clientId
 
+@description('Resource ID of the Terraform State storage account.')
+output storageAccountId string = !empty(storageAccountName) ? storageAccount.outputs.resourceId : ''
+
 // @description('Resource ID of the Plan Managed Identity.')
 // output planManagedIdentityResourceId string = planManagedIdentity.outputs.resourceId
 

--- a/templates/environment-infra.bicep
+++ b/templates/environment-infra.bicep
@@ -22,7 +22,7 @@ param gitHubPlanEnvironmentName string
 param gitHubApplyEnvironmentName string
 
 @description('Name of the Storage Account to create. If not supplied, no storage account will be created.')
-param storageAccountName string = ''
+param terraformStateStorageAccountName string = ''
 
 @description('Retention days for blob delete retention policy.')
 param retentionDays int = 7
@@ -139,11 +139,11 @@ module applyMiRbacAdmin './rbac.bicep' = {
   }
 }
 
-module storageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = if (!empty(storageAccountName)) {
-  name: 'tfstorage-${uniqueString(storageAccountName)}'
+module storageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = if (!empty(terraformStateStorageAccountName)) {
+  name: 'tfstorage-${uniqueString(terraformStateStorageAccountName)}'
   scope: resourceGroup(resourceGroupName)
   params: {
-    name: storageAccountName
+    name: terraformStateStorageAccountName
     location: location
     skuName: 'Standard_LRS'
     kind: 'StorageV2'
@@ -221,7 +221,7 @@ output planManagedIdentityClientId string = planManagedIdentity.outputs.clientId
 output applyManagedIdentityClientId string = applyManagedIdentity.outputs.clientId
 
 @description('Resource ID of the Terraform State storage account.')
-output storageAccountId string = !empty(storageAccountName) ? storageAccount.outputs.resourceId : ''
+output terraformStateStorageAccountId string = !empty(terraformStateStorageAccountName) ? storageAccount.outputs.resourceId : ''
 
 // @description('Resource ID of the Plan Managed Identity.')
 // output planManagedIdentityResourceId string = planManagedIdentity.outputs.resourceId


### PR DESCRIPTION
This PR introduces the deployment stack feature and adds an optional Terraform state storage account to the deployment infrastructure. Key changes include:

- Adding new parameters and a storage account module in the Bicep template to support an optional storage account.
- Updating several PowerShell scripts (Invoke-AzBootstrap.ps1, Add-AzBootstrapEnvironment.ps1, New-AzBicepDeployment.ps1) to include and pass the new storage account parameter.
- Refreshing integration tests and examples to accommodate the new storage account and deployment stack command changes.